### PR TITLE
Adopt to the size_type change in the Accessor

### DIFF
--- a/cuda/dot_kernels.cuh
+++ b/cuda/dot_kernels.cuh
@@ -232,8 +232,8 @@ void acc_dot(myBlasHandle *handle, const matrix_info x_info, const StType *x,
 
     // Accessor Setup
     constexpr std::size_t dimensionality{2};
-    std::array<std::size_t, dimensionality - 1> x_stride{x_info.stride};
-    std::array<std::size_t, dimensionality - 1> y_stride{y_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> x_stride{x_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> y_stride{y_info.stride};
 
     using accessor =
         gko::acc::reduced_row_major<dimensionality, ArType, StType>;

--- a/cuda/dot_memory.cuh
+++ b/cuda/dot_memory.cuh
@@ -34,7 +34,7 @@ public:
      * @param engine  random engine used to generate the values
      */
     template <typename VectDist, typename RndEngine>
-    DotMemory(std::size_t size, VectDist &&vect_dist, RndEngine &&engine)
+    DotMemory(matrix_info::size_type size, VectDist &&vect_dist, RndEngine &&engine)
         : x_info_{{size, 1}},
           y_info_{{size, 1}},
           cpu_x_(gen_mtx<ValueType>(x_info_, vect_dist, engine)),

--- a/cuda/gemv_benchmark.cu
+++ b/cuda/gemv_benchmark.cu
@@ -20,15 +20,16 @@ int main(int argc, char **argv)
 {
     using ar_type = double;
     using st_type = float;
+    using size_type = matrix_info::size_type;
 
     constexpr ar_type ar_alpha{1.0};
     constexpr ar_type ar_beta{1.0};
     constexpr st_type st_alpha{static_cast<st_type>(ar_alpha)};
     constexpr st_type st_beta{static_cast<st_type>(ar_beta)};
 
-    constexpr std::size_t default_max_size{24500};
-    constexpr std::size_t min_size{100};
-    std::size_t max_size{default_max_size};
+    constexpr size_type default_max_size{24500};
+    constexpr size_type min_size{100};
+    size_type max_size{default_max_size};
 
     bool measure_error{false};
 
@@ -122,7 +123,7 @@ int main(int argc, char **argv)
         return error / res_ref_norm;
     };
 
-    constexpr std::size_t benchmark_reference{0};
+    constexpr size_type benchmark_reference{0};
     using benchmark_info_t =
         std::tuple<std::string,
                    std::function<void(matrix_info, matrix_info, matrix_info)>,
@@ -190,7 +191,7 @@ int main(int argc, char **argv)
             },
             st_compute_error},
     };
-    const std::size_t benchmark_num{benchmark_info.size()};
+    const size_type benchmark_num{static_cast<size_type>(benchmark_info.size())};
 
     std::cout << "Num rows";
     for (const auto &info : benchmark_info) {
@@ -209,7 +210,7 @@ int main(int argc, char **argv)
     std::vector<ar_type> local_res(benchmark_num);
     constexpr auto start = min_size;
     constexpr auto row_incr = start;
-    for (std::size_t num_rows = start; num_rows <= max_size;
+    for (size_type num_rows = start; num_rows <= max_size;
          num_rows += row_incr) {
         const matrix_info m_info{{num_rows, num_rows}, max_size};
         const matrix_info x_info{{num_rows, 1}};
@@ -229,7 +230,7 @@ int main(int argc, char **argv)
                 ar_data.gpu_res_memory().copy_from(ar_cpu_res_init);
             }
         }
-        for (std::size_t i = 0; i < benchmark_num; ++i) {
+        for (size_type i = 0; i < benchmark_num; ++i) {
             auto local_func = [&]() {
                 std::get<1>(benchmark_info[i])(m_info, x_info, res_info);
             };

--- a/cuda/gemv_kernels.cuh
+++ b/cuda/gemv_kernels.cuh
@@ -176,9 +176,9 @@ void acc_gemv(const matrix_info m_info, ArType alpha, const StType *mtx,
 
     // Accessor Setup
     constexpr std::size_t dimensionality{2};
-    std::array<std::size_t, dimensionality - 1> m_stride{m_info.stride};
-    std::array<std::size_t, dimensionality - 1> x_stride{x_info.stride};
-    std::array<std::size_t, dimensionality - 1> res_stride{res_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> m_stride{m_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> x_stride{x_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> res_stride{res_info.stride};
 
     using accessor =
         gko::acc::reduced_row_major<dimensionality, ArType, StType>;

--- a/cuda/gemv_memory.cuh
+++ b/cuda/gemv_memory.cuh
@@ -37,7 +37,7 @@ public:
      * @param engine  random engine used to generate the values
      */
     template <typename MtxDist, typename VectDist, typename RndEngine>
-    GemvMemory(std::size_t max_size, MtxDist &&mtx_dist,
+    GemvMemory(matrix_info::size_type max_size, MtxDist &&mtx_dist,
                VectDist &&vect_dist, RndEngine &&engine)
         : m_info_{{max_size, max_size}},
           x_info_{{max_size, 1}},

--- a/cuda/trsv_benchmark.cu
+++ b/cuda/trsv_benchmark.cu
@@ -21,14 +21,15 @@ int main(int argc, char **argv)
 {
     using ar_type = double;
     using st_type = float;
+    using size_type = matrix_info::size_type;
 
     constexpr tmtx_t t_matrix_type = tmtx_t::upper;
     constexpr dmtx_t d_matrix_type = dmtx_t::unit;
 
-    constexpr std::size_t default_max_size{24 * 1000};
-    constexpr std::size_t min_size{100};
+    constexpr size_type default_max_size{24 * 1000};
+    constexpr size_type min_size{100};
 
-    std::size_t max_size{default_max_size};
+    auto max_size{default_max_size};
     bool measure_error{false};
 
     const std::string use_error_string("--error");
@@ -196,8 +197,8 @@ int main(int argc, char **argv)
 
     std::vector<ar_type> local_res(benchmark_num);
 
-    const std::size_t start = std::min(max_size, min_size);
-    const std::size_t row_incr = start;
+    const auto start = std::min(max_size, min_size);
+    const auto row_incr = start;
 
     for (auto num_rows = start; num_rows <= max_size; num_rows += row_incr) {
         const matrix_info m_info{{num_rows, num_rows}, max_size};

--- a/cuda/trsv_kernels.cuh
+++ b/cuda/trsv_kernels.cuh
@@ -86,7 +86,7 @@ __global__ __launch_bounds__(swarps_per_block *swarp_size) void lower_trsv(
 
     // stores the trianglular system in column major
     __shared__ ValueType triang[swarp_size * triang_stride];
-    __shared__ std::uint32_t shared_row_block_idx;
+    __shared__ std::int32_t shared_row_block_idx;
     __shared__ ValueType x_correction[swarp_size];
 
     const auto group = cg::this_thread_block();
@@ -280,7 +280,7 @@ __global__ __launch_bounds__(swarps_per_block *swarp_size) void upper_trsv(
 
     // stores the trianglular system in column major
     __shared__ ValueType triang[swarp_size * triang_stride];
-    __shared__ std::uint32_t shared_row_block_idx;
+    __shared__ std::int32_t shared_row_block_idx;
     __shared__ ValueType x_correction[swarp_size];
 
     const auto group = cg::this_thread_block();
@@ -461,7 +461,7 @@ void trsv(const matrix_info m_info, tmtx_t ttype, dmtx_t dtype,
     constexpr std::int32_t swarps_per_block{4};
     const dim3 block_solve(subwarp_size, swarps_per_block, 1);
     const dim3 grid_solve(
-        ceildiv(m_info.size[0], static_cast<std::size_t>(subwarp_size)), 1, 1);
+        ceildiv(m_info.size[0], static_cast<std::int64_t>(subwarp_size)), 1, 1);
 
     kernel::trsv_init<<<1, 1>>>(trsv_helper);
     if (dtype == dmtx_t::unit) {
@@ -544,7 +544,7 @@ __global__ __launch_bounds__(swarps_per_block *swarp_size) void acc_lower_trsv(
 
     // stores the trianglular system in column major
     __shared__ ar_type triang[swarp_size * triang_stride];
-    __shared__ std::uint32_t shared_row_block_idx;
+    __shared__ std::int32_t shared_row_block_idx;
     __shared__ ar_type x_correction[swarp_size];
 
     const auto group = cg::this_thread_block();
@@ -742,7 +742,7 @@ __global__ __launch_bounds__(swarps_per_block *swarp_size) void acc_upper_trsv(
 
     // stores the trianglular system in column major
     __shared__ ar_type triang[swarp_size * triang_stride];
-    __shared__ std::uint32_t shared_row_block_idx;
+    __shared__ std::int32_t shared_row_block_idx;
     __shared__ ar_type x_correction[swarp_size];
 
     const auto group = cg::this_thread_block();
@@ -922,8 +922,8 @@ void acc_trsv(const matrix_info m_info, tmtx_t ttype, dmtx_t dtype,
 {
     // Accessor Setup
     constexpr std::size_t dimensionality{2};
-    std::array<std::size_t, dimensionality - 1> m_stride{m_info.stride};
-    std::array<std::size_t, dimensionality - 1> x_stride{x_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> m_stride{m_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> x_stride{x_info.stride};
 
     using accessor =
         gko::acc::reduced_row_major<dimensionality, ArType, StType>;
@@ -936,7 +936,7 @@ void acc_trsv(const matrix_info m_info, tmtx_t ttype, dmtx_t dtype,
     constexpr std::int32_t swarps_per_block{4};
     const dim3 block_solve(subwarp_size, swarps_per_block, 1);
     const dim3 grid_solve(
-        ceildiv(m_info.size[0], static_cast<std::size_t>(subwarp_size)), 1, 1);
+        ceildiv(m_info.size[0], static_cast<std::int64_t>(subwarp_size)), 1, 1);
 
     kernel::trsv_init<<<1, 1>>>(trsv_helper);
     if (dtype == dmtx_t::unit) {

--- a/cuda/trsv_memory.cuh
+++ b/cuda/trsv_memory.cuh
@@ -108,7 +108,7 @@ public:
      *                      initializing)
      */
     template <typename MtxGen, typename VectGen>
-    TrsvMemory(std::size_t max_size, MtxGen &&cpu_mtx_gen,
+    TrsvMemory(matrix_info::size_type max_size, MtxGen &&cpu_mtx_gen,
                VectGen &&cpu_vect_gen)
         : m_info_{{max_size, max_size}},
           x_info_{{max_size, 1}},
@@ -139,7 +139,7 @@ public:
         const auto pivot_size = std::max(m_info_.size[0], m_info_.size[1]);
         Memory<int> cpu_pivot(Memory<int>::Device::cpu, pivot_size);
         Memory<int> gpu_pivot(Memory<int>::Device::gpu, pivot_size);
-        for (std::size_t i = 0; i < pivot_size; ++i) {
+        for (matrix_info::size_type i = 0; i < pivot_size; ++i) {
             cpu_pivot.data()[i] = i;
         }
         gpu_pivot = cpu_pivot;

--- a/cuda/utils.cuh
+++ b/cuda/utils.cuh
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cassert>
+#include <cinttypes>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -15,10 +16,11 @@
  * Contains information about a row-major matrix.
  */
 struct matrix_info {
+    using size_type = std::int64_t;
     // 2D size of the matrix
-    const std::array<std::size_t, 2> size;
+    const std::array<size_type, 2> size;
     // stride used for the rows.
-    const std::size_t stride;
+    const size_type stride;
 
     /**
      * Sets the given size and stride.
@@ -26,8 +28,8 @@ struct matrix_info {
      * @param size  2D size
      * @param stride  stride (must be larger than size[1])
      */
-    constexpr matrix_info(const std::array<std::size_t, 2> size,
-                          const std::size_t stride)
+    constexpr matrix_info(const std::array<size_type, 2> size,
+                          const size_type stride)
         : size(size), stride{stride}
     {}
 
@@ -37,7 +39,7 @@ struct matrix_info {
      * @param size  2D size
      * @param stride  stride (must be larger than size[1])
      */
-    constexpr matrix_info(const std::array<std::size_t, 2> size)
+    constexpr matrix_info(const std::array<size_type, 2> size)
         : matrix_info{size, size[1]}
     {}
 
@@ -45,12 +47,12 @@ struct matrix_info {
      * @returns the total amount of elements (including elements in the stride)
      *          this matrix occupies.
      */
-    std::size_t get_1d_size() const { return size[0] * stride; }
+    size_type get_1d_size() const { return size[0] * stride; }
     /**
      * @returns the number of elements the matrix has (does not consider the
      *          stride)
      */
-    std::size_t get_num_elems() const { return size[0] * size[1]; }
+    size_type get_num_elems() const { return size[0] * size[1]; }
 };
 
 
@@ -281,13 +283,13 @@ OutputType reduce(const matrix_info info, InputType *tmp, ReduceOp op)
 {
     // The given matrix must only have a single column!
     assert(info.size[1] == 1);
-    std::size_t end = info.size[0];
-    for (std::size_t halfway = ceildiv(info.size[0], std::size_t{2});
-         halfway > 1; halfway = ceildiv(halfway, std::size_t{2})) {
-        for (std::size_t row = 0; row < halfway; ++row) {
+    std::int64_t end = info.size[0];
+    for (std::int64_t halfway = ceildiv(info.size[0], std::int64_t{2});
+         halfway > 1; halfway = ceildiv(halfway, std::int64_t{2})) {
+        for (std::int64_t row = 0; row < halfway; ++row) {
             if (row + halfway < end) {
-                const std::size_t midx = row * info.stride;
-                const std::size_t midx2 = (row + halfway) * info.stride;
+                const auto midx = row * info.stride;
+                const auto midx2 = (row + halfway) * info.stride;
                 tmp[midx] = op(tmp[midx], tmp[midx2]);
             }
         }
@@ -317,8 +319,8 @@ ValueType compare(const matrix_info info, const ReferenceType *mtx1,
     // The given matrix must only have a single column!
     assert(info.size[1] == 1);
 
-    for (std::size_t row = 0; row < info.size[0]; ++row) {
-        const std::size_t midx = row * info.stride;
+    for (typename matrix_info::size_type row = 0; row < info.size[0]; ++row) {
+        const auto midx = row * info.stride;
         const ValueType v1 = mtx1[midx];
         const ValueType v2 = mtx2[midx];
         const auto delta = std::abs(v1 - v2);


### PR DESCRIPTION
The Accessor inside Ginkgo was recently changed to use `std::int64_t` instead of `std::size_t` as the `size_type`. This PR adopts this change to this repository as well.