### PR TITLE
Update the README code sample links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use Ginkgo's accessor, you need to:
 In this repository, we use CMake, which makes the integration straight forward.
 We give users the option to either specify a local copy of the Ginkgo repository, or automatically clone the repository into the build directory, followed by using it.
 We achieve both with these few lines in CMake:  
-https://github.com/ginkgo-project/accessor-BLAS/blob/10adcedbbbdc67a5f1093ff7284890085d0d24e4/CMakeLists.txt#L16-L43  
+https://github.com/ginkgo-project/accessor-BLAS/blob/8137ba67b60c7ce5f9a299e02d649364a45d21a4/CMakeLists.txt#L16-L43
 Now, we only need to call this function for every target where we use the accessor.
 
 
@@ -24,7 +24,7 @@ For the `reduced_row_major` accessor, you need to specify:
 Now, this type can be used to create the `range<reduced_row_major<...>>` by specifying the size, stride and storage pointer.
 
 We showcase the creation of both constant and non-constant ranges with `reduced_row_major` accessors here:  
-https://github.com/ginkgo-project/accessor-BLAS/blob/10adcedbbbdc67a5f1093ff7284890085d0d24e4/cuda/gemv_kernels.cuh#L178-L189  
+https://github.com/ginkgo-project/accessor-BLAS/blob/8137ba67b60c7ce5f9a299e02d649364a45d21a4/cuda/gemv_kernels.cuh#L178-L189
 We utilize the constant accessors for the matrix and the x vector since both storage pointers are also constant.
 
 
@@ -35,19 +35,19 @@ Utilizing the range in a kernel (works the same for CPUs) is straight forward:
 2. Read and write operations utilize the bracket operator()
 
 To know which arithmetic type is used, we can either use the `accessor::arithmetic_type` property, or detect what type arithmetic operations result in. In this example, we use the second option:  
-https://github.com/ginkgo-project/accessor-BLAS/blob/10adcedbbbdc67a5f1093ff7284890085d0d24e4/cuda/gemv_kernels.cuh#L86
+https://github.com/ginkgo-project/accessor-BLAS/blob/8137ba67b60c7ce5f9a299e02d649364a45d21a4/cuda/gemv_kernels.cuh#L86
 
 Read and write options can be observed in GEMV here:  
-https://github.com/ginkgo-project/accessor-BLAS/blob/10adcedbbbdc67a5f1093ff7284890085d0d24e4/cuda/gemv_kernels.cuh#L110
+https://github.com/ginkgo-project/accessor-BLAS/blob/8137ba67b60c7ce5f9a299e02d649364a45d21a4/cuda/gemv_kernels.cuh#L110
 
 
 ### Difference between using plain pointers and using the range/accessor
 
 Here, we compare the GEMV kernel written with plain pointers:  
-https://github.com/ginkgo-project/accessor-BLAS/blob/10adcedbbbdc67a5f1093ff7284890085d0d24e4/cuda/gemv_kernels.cuh#L30-L64
+https://github.com/ginkgo-project/accessor-BLAS/blob/8137ba67b60c7ce5f9a299e02d649364a45d21a4/cuda/gemv_kernels.cuh#L30-L64
 
 and using the range/accessor:  
-https://github.com/ginkgo-project/accessor-BLAS/blob/10adcedbbbdc67a5f1093ff7284890085d0d24e4/cuda/gemv_kernels.cuh#L79-L113
+https://github.com/ginkgo-project/accessor-BLAS/blob/8137ba67b60c7ce5f9a299e02d649364a45d21a4/cuda/gemv_kernels.cuh#L79-L113
 
 
 The main differences between these are:


### PR DESCRIPTION
This PR simply updates the code samples with updated links (only the content of the creation of the accessor, so the second link, actually changed because of the `size_type` change).