### PR TITLE
Add AXPY benchmark (with some fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+build/
+
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+# CLion
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#cmake-build-*

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -29,3 +29,4 @@ find_library(CUSOLVER cusolver
 create_cuda_executable("gemv_benchmark" "gemv_benchmark.cu" "${CUBLAS}")
 create_cuda_executable("dot_benchmark" "dot_benchmark.cu" "${CUBLAS}")
 create_cuda_executable("trsv_benchmark" "trsv_benchmark.cu" "${CUBLAS}" "${CUSOLVER}")
+create_cuda_executable("axpy_benchmark" "axpy_benchmark.cu" "${CUBLAS}")

--- a/cuda/axpy_benchmark.cu
+++ b/cuda/axpy_benchmark.cu
@@ -1,0 +1,240 @@
+#include <cmath>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <typeinfo>
+#include <vector>
+
+
+#include "axpy_kernels.cuh"
+#include "axpy_memory.cuh"
+#include "memory.cuh"
+#include "utils.cuh"
+
+
+int main(int argc, char **argv)
+{
+    using ar_type = double;
+    using st_type = float;
+    using size_type = matrix_info::size_type;
+
+    constexpr ar_type ar_alpha{1.0};
+    constexpr st_type st_alpha{static_cast<st_type>(ar_alpha)};
+
+    constexpr size_type min_size{1'000'000};
+    constexpr size_type default_max_size{535 * 1000 * 1000};
+    constexpr char DELIM{';'};
+
+    bool measure_error{false};
+    size_type max_size{default_max_size};
+
+    const std::string use_error_string("--error");
+    const std::string set_size_string("--size");
+
+    auto print_usage = [&]() {
+        const std::string binary(argv[0]);
+        std::cerr << "Usage: " << binary << " [" << use_error_string << "] "
+                  << '[' << set_size_string << "=SIZE"
+                  << "]\n";
+        std::cerr << "With:\n"
+                  << use_error_string << ":    compute the error of the AXPYs\n"
+                  << set_size_string
+                  << ":     set the maximum size of a vector. Default value: "
+                  << default_max_size << "; Min value: " << min_size << '\n'
+                  << "Without parameters: benchmark different AXPYs\n";
+    };
+
+    // Process the input arguments
+    for (int i = 1; i < argc; ++i) {
+        const std::string current(argv[i]);
+        if (current == use_error_string) {
+            measure_error = true;
+        } else if (current.substr(0, set_size_string.size()) ==
+                   set_size_string) {
+            max_size = std::stoll(current.substr(set_size_string.size() + 1));
+        } else {
+            std::cerr << "Unsupported parameter: " << current << '\n';
+            print_usage();
+            return 1;
+        }
+    }
+    if (max_size < min_size) {
+        std::cerr << "The vector size needs to be at least " << min_size
+                  << '\n';
+        return 1;
+    }
+
+    // The result vector only needs to be reset if we measure the error.
+    // Otherwise, the initial result values don't matter for the computation.
+    const bool reset_result{measure_error};
+    const bool normalize_error{true};
+
+    std::default_random_engine rengine(42);
+    std::uniform_real_distribution<ar_type> vector_dist(-1.0, 1.0);
+
+    // Allocate host and device memory
+    auto ar_data = AxpyMemory<ar_type>(max_size, vector_dist, rengine);
+    auto st_data = AxpyMemory<st_type>(ar_data);
+
+    auto cublas_handle = cublas_get_handle();
+    cublas_set_device_ptr_mode(cublas_handle.get());
+
+    auto my_handle = std::make_unique<myBlasHandle>();
+
+    // Snapshot of the randomly initialized `res`, used to restore a clean
+    // starting point before/after every error measurement.
+    auto ar_cpu_res_init = ar_data.cpu_res_memory();
+    auto st_cpu_res_init = st_data.cpu_res_memory();
+
+    // Additional memory and lambdas for error computation
+    const auto max_res_num_elems = ar_data.cpu_res_memory().get_num_elems();
+    Memory<ar_type> cpu_res_ref(Memory<ar_type>::Device::cpu,
+                                max_res_num_elems);
+    ar_type res_ref_norm{1.0};
+    Memory<ar_type> reduce_memory(Memory<ar_type>::Device::cpu,
+                                  max_res_num_elems);
+    auto ar_compute_error = [&](matrix_info res_info) {
+        ar_type error{};
+        if (measure_error) {
+            ar_data.sync_result();
+            error = compare(res_info, cpu_res_ref.const_data(),
+                            ar_data.cpu_res(), reduce_memory.data());
+        }
+        if (reset_result) {
+            ar_data.gpu_res_memory() = ar_cpu_res_init;
+        }
+        return error / res_ref_norm;
+    };
+    auto st_compute_error = [&](matrix_info res_info) {
+        ar_type error{};
+        if (measure_error) {
+            st_data.sync_result();
+            error = compare(res_info, cpu_res_ref.const_data(),
+                            st_data.cpu_res(), reduce_memory.data());
+        }
+        if (reset_result) {
+            st_data.gpu_res_memory() = st_cpu_res_init;
+        }
+        return error / res_ref_norm;
+    };
+
+    constexpr size_type benchmark_reference{0};
+    using benchmark_info_t =
+        std::tuple<std::string, std::function<void(matrix_info, matrix_info)>,
+                   std::function<ar_type(matrix_info)>>;
+    // This vector contains all necessary information to perform the
+    // benchmark. First, the name of the benchmark, second, a lambda taking
+    // the x and res information of the vectors which then runs the
+    // corresponding kernel, third, a lambda computing the (normalized) error
+    // of the result for that benchmark.
+    std::vector<benchmark_info_t> benchmark_info = {
+        benchmark_info_t{"AXPY fp64",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             axpy(my_handle.get(), ar_alpha, x_info,
+                                  ar_data.gpu_x(), res_info, ar_data.gpu_res());
+                         },
+                         ar_compute_error},
+        benchmark_info_t{"AXPY fp32",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             axpy(my_handle.get(), st_alpha, x_info,
+                                  st_data.gpu_x(), res_info, st_data.gpu_res());
+                         },
+                         st_compute_error},
+        benchmark_info_t{"AXPY Acc<fp64, fp64>",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             acc_axpy<ar_type>(my_handle.get(), ar_alpha,
+                                               x_info, ar_data.gpu_x(),
+                                               res_info, ar_data.gpu_res());
+                         },
+                         ar_compute_error},
+        benchmark_info_t{"AXPY Acc<fp64, fp32>",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             acc_axpy<ar_type>(my_handle.get(), ar_alpha,
+                                               x_info, st_data.gpu_x(),
+                                               res_info, st_data.gpu_res());
+                         },
+                         st_compute_error},
+        benchmark_info_t{"AXPY Acc<fp32, fp32>",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             acc_axpy<st_type>(my_handle.get(), st_alpha,
+                                               x_info, st_data.gpu_x(),
+                                               res_info, st_data.gpu_res());
+                         },
+                         st_compute_error},
+        benchmark_info_t{"CUBLAS AXPY fp64",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             cublas_axpy(cublas_handle.get(), ar_alpha, x_info,
+                                         ar_data.gpu_x(), res_info,
+                                         ar_data.gpu_res());
+                         },
+                         ar_compute_error},
+        benchmark_info_t{"CUBLAS AXPY fp32",
+                         [&](matrix_info x_info, matrix_info res_info) {
+                             cublas_axpy(cublas_handle.get(), st_alpha, x_info,
+                                         st_data.gpu_x(), res_info,
+                                         st_data.gpu_res());
+                         },
+                         st_compute_error}};
+    const size_type benchmark_num{
+        static_cast<size_type>(benchmark_info.size())};
+
+    std::cout << "Vector Size";
+    for (const auto &info : benchmark_info) {
+        if (!measure_error) {
+            std::cout << DELIM << std::get<0>(info);
+        } else {
+            std::cout << DELIM << "Error " << std::get<0>(info);
+        }
+    }
+    std::cout << '\n';
+
+    std::cout.precision(16);
+    std::cout << std::scientific;
+
+    std::vector<ar_type> local_res(benchmark_num);
+    const size_type start = min_size;
+    constexpr size_type row_incr = 2'000'000;
+    for (size_type vec_size = start; vec_size <= max_size;
+         vec_size += row_incr) {
+        const matrix_info x_info{{vec_size, 1}};
+        const matrix_info res_info{{vec_size, 1}};
+
+        if (measure_error) {
+            // Run the reference benchmark once to get the result it computes
+            // (and its norm), then reset `res` so every benchmark below
+            // starts from the same clean state.
+            std::get<1>(benchmark_info[benchmark_reference])(x_info, res_info);
+            cpu_res_ref.copy_from(ar_data.gpu_res_memory());
+            if (normalize_error) {
+                res_ref_norm = reduce<ar_type>(
+                    res_info, cpu_res_ref.data(), [](ar_type a, ar_type b) {
+                        return std::abs(a) + std::abs(b);
+                    });
+                // copy again since the reduce operation overwrites
+                cpu_res_ref.copy_from(ar_data.gpu_res_memory());
+                ar_data.gpu_res_memory() = ar_cpu_res_init;
+            }
+        }
+        for (size_type i = 0; i < benchmark_num; ++i) {
+            auto local_func = [&]() {
+                std::get<1>(benchmark_info[i])(x_info, res_info);
+            };
+            if (!measure_error) {
+                local_res[i] = benchmark_function(local_func, measure_error);
+            } else {
+                benchmark_function(local_func, measure_error);
+                local_res[i] = std::get<2>(benchmark_info[i])(res_info);
+            }
+        }
+
+        std::cout << vec_size;
+        for (const auto &res : local_res) {
+            std::cout << DELIM << res;
+        }
+        std::cout << '\n';
+    }
+}

--- a/cuda/axpy_kernels.cuh
+++ b/cuda/axpy_kernels.cuh
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <cinttypes>
+
+
+#include <cooperative_groups.h>
+#include <cublas_v2.h>
+
+
+// Accessor headers
+#include "accessor/range.hpp"
+#include "accessor/reduced_row_major.hpp"
+
+
+#include "kernel_utils.cuh"
+#include "utils.cuh"
+
+
+constexpr int axpy_blocks_per_sm{32};
+constexpr int axpy_block_size{512};
+
+
+namespace kernel {
+
+
+namespace cg = cooperative_groups;
+
+
+/**
+ * Computes the AXPY: res = alpha * x + res
+ */
+template <std::int64_t block_size, typename ValueType>
+__global__ __launch_bounds__(block_size) void axpy(
+    ValueType alpha, const matrix_info x_info, const ValueType *__restrict__ x,
+    const matrix_info res_info, ValueType *__restrict__ res)
+{
+    // expect x_info.size[1] == 1
+    const std::uint64_t global_tidx = blockIdx.x * block_size + threadIdx.x;
+    const std::uint64_t grid_stride = block_size * gridDim.x;
+
+    for (std::uint64_t i = global_tidx; i < x_info.size[0]; i += grid_stride) {
+        const auto x_idx = i * x_info.stride;
+        const auto res_idx = i * res_info.stride;
+
+        res[res_idx] = alpha * x[x_idx] + res[res_idx];
+    }
+}
+
+/**
+ * Computes the AXPY: res = alpha * x + res
+ *
+ * @internal The main difference to the non-accessor AXPY implementation is that
+ *           the information how data is accessed is now stored in the accessor
+ *           and not as a separate parameter. Other than that, only the read and
+ *           write accesses are different, as they now go through the accessor
+ *           instead of being hand-computed.
+ */
+template <std::int64_t block_size, typename XRange, typename ResRange,
+          typename ArType>
+__global__ __launch_bounds__(block_size) void acc_axpy(ArType alpha, XRange x,
+                                                       ResRange res)
+{
+    using ar_type = decltype(alpha * x(0, 0) + res(0, 0));
+    static_assert(std::is_same<ArType, ar_type>::value, "Types must be equal!");
+    // expect x_info.size[1] == 1
+    const std::uint64_t global_tidx = blockIdx.x * block_size + threadIdx.x;
+    const std::uint64_t grid_stride = block_size * gridDim.x;
+
+    for (std::uint64_t i = global_tidx; i < x.length(0); i += grid_stride) {
+        res(i, 0) = alpha * x(i, 0) + res(i, 0);
+    }
+}
+}  // namespace kernel
+
+
+/**
+ * Computes the AXPY: res = alpha * x + res
+ * using a self-implemented kernel without the accessor.
+ *
+ * @tparam ValueType  type of the input and output parameters
+ *
+ * @param alpha  alpha factor for the AXPY
+ * @param x_info  Information about the x vector
+ * @param x  x vector
+ * @param res_info  Information about the res vector
+ * @param res  res vector
+ **/
+template <typename ValueType>
+void axpy(myBlasHandle *handle, ValueType alpha, const matrix_info x_info,
+          const ValueType *x, const matrix_info res_info, ValueType *res)
+{
+    constexpr std::int32_t block_size{axpy_block_size};
+    const dim3 block(block_size, 1, 1);
+    const dim3 grid(
+        handle->get_device_property().multiProcessorCount * axpy_blocks_per_sm,
+        1, 1);
+
+    kernel::axpy<block_size, ValueType>
+        <<<grid, block>>>(alpha, x_info, x, res_info, res);
+}
+
+/**
+ * Computes the AXPY: res = alpha * x + res
+ * using a kernel utilizing the accessor.
+ *
+ * @tparam ArType  arithmetic type that should be used in the AXPY
+ * @tparam StType  storage type of the AXPY
+ *
+ * @param alpha  alpha factor for the AXPY
+ * @param x_info  Information about the x vector
+ * @param x  x vector
+ * @param res_info  Information about the res vector
+ * @param res  res vector
+ **/
+template <typename ArType, typename StType>
+void acc_axpy(myBlasHandle *handle, ArType alpha, const matrix_info x_info,
+              const StType *x, const matrix_info res_info, StType *res)
+{
+    constexpr std::int32_t block_size{axpy_block_size};
+    const dim3 block(block_size, 1, 1);
+    const dim3 grid(
+        handle->get_device_property().multiProcessorCount * axpy_blocks_per_sm,
+        1, 1);
+
+    // Accessor Setup
+    constexpr std::size_t dimensionality{2};
+    std::array<gko::acc::size_type, dimensionality - 1> x_stride{x_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> res_stride{
+        res_info.stride};
+
+    using accessor =
+        gko::acc::reduced_row_major<dimensionality, ArType, StType>;
+    using range = gko::acc::range<accessor>;
+    using c_range = gko::acc::range<typename accessor::const_accessor>;
+    auto x_acc = c_range(x_info.size, x, x_stride);
+    auto res_acc = range(res_info.size, res, res_stride);
+
+    kernel::acc_axpy<block_size><<<grid, block>>>(alpha, x_acc, res_acc);
+}
+
+// Use a macro to overload the CUBLAS AXPY calls instead of hand-writing them.
+// Also allows for easier extension (for example for complex types).
+#define BIND_CUBLAS_AXPY(ValueType, CublasName)                            \
+    void cublas_axpy(cublasHandle_t handle, int n, const ValueType *alpha, \
+                     const ValueType *x, int incx, ValueType *y, int incy) \
+    {                                                                      \
+        CUBLAS_CALL(CublasName(handle, n, alpha, x, incx, y, incy));       \
+    }
+BIND_CUBLAS_AXPY(double, cublasDaxpy)
+BIND_CUBLAS_AXPY(float, cublasSaxpy)
+#undef BIND_CUBLAS_AXPY
+
+
+/**
+ * Computes the AXPY: res = alpha * x + res
+ * using the CUBLAS vendor implementation
+ *
+ * @tparam ValueType  type of the input and output parameters
+ *
+ * @param haldle  CUBLAS handle which is required for CUBLAS operations
+ * @param alpha  alpha factor for the AXPY
+ * @param x_info  Information about the x vector
+ * @param x  x vector
+ * @param res_info  Information about the res vector
+ * @param res  res vector
+ **/
+template <typename ValueType>
+void cublas_axpy(cublasHandle_t handle, ValueType alpha,
+                 const matrix_info x_info, const ValueType *x,
+                 const matrix_info res_info, ValueType *res)
+{
+    cublas_axpy(handle, static_cast<int>(x_info.size[0]), &alpha, x,
+                static_cast<int>(x_info.stride), res,
+                static_cast<int>(res_info.stride));
+}

--- a/cuda/axpy_memory.cuh
+++ b/cuda/axpy_memory.cuh
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <type_traits>
+
+
+#include "matrix_helper.cuh"
+#include "memory.cuh"
+#include "utils.cuh"
+
+
+/**
+ * Manages the host and device memory for all AXPY benchmarks in the specified
+ * precision.
+ *
+ * @tparam ValueType  The precision the managed data is in.
+ */
+template <typename ValueType>
+class AxpyMemory {
+private:
+    static constexpr auto CPU_device = Memory<ValueType>::Device::cpu;
+    static constexpr auto GPU_device = Memory<ValueType>::Device::gpu;
+
+public:
+    /**
+     * Allocates and initializes the memory randomly (with the given
+     * distribution) and mirrors that data for both CPU and GPU. Random values
+     * are generated on the CPU with vect_dist(engine).
+     *
+     * @tparam VectDist  type of the distribution
+     * @tparam RndEngine  type of the random engine
+     *
+     * @param size  the size of each vector that is generated
+     * @param vect_dist  distribution for the randomly generated values
+     * @param engine  random engine used to generate the values
+     */
+    template <typename VectDist, typename RndEngine>
+    AxpyMemory(matrix_info::size_type size, VectDist &&vect_dist,
+               RndEngine &&engine)
+        : x_info_{{size, 1}},
+          res_info_{{size, 1}},
+          cpu_x_(gen_mtx<ValueType>(x_info_, vect_dist, engine)),
+          cpu_res_(gen_mtx<ValueType>(res_info_, vect_dist, engine)),
+          gpu_x_(GPU_device, x_info_.get_1d_size()),
+          gpu_res_(GPU_device, res_info_.get_1d_size())
+    {
+        copy_cpu_to_gpu();
+    }
+
+    /**
+     * Creates a copy of the data from another AxpyMemory (with potentially a
+     * different memory type). To convert different memory types, static_cast is
+     * used.
+     *
+     * @tparam OtherType  memory type of the other object (can be different from
+     * ValueType)
+     *
+     * @param other  AxpyMemory object that is copied.
+     */
+    template <typename OtherType>
+    AxpyMemory(const AxpyMemory<OtherType> &other)
+        : x_info_(other.x_info_),
+          res_info_(other.res_info_),
+          cpu_x_(CPU_device, x_info_.get_1d_size()),
+          cpu_res_(CPU_device, res_info_.get_1d_size()),
+          gpu_x_(GPU_device, x_info_.get_1d_size()),
+          gpu_res_(GPU_device, res_info_.get_1d_size())
+    {
+        convert(other);
+        copy_cpu_to_gpu();
+    }
+
+    /**
+     * Syncronizes the result from GPU to CPU.
+     */
+    void sync_result() { cpu_res_.copy_from(gpu_res_); }
+
+    /**
+     * Copies all memory from CPU to GPU.
+     */
+    void copy_cpu_to_gpu()
+    {
+        gpu_x_.copy_from(cpu_x_);
+        gpu_res_.copy_from(cpu_res_);
+    }
+
+private:
+    template <typename OtherType>
+    void convert(const AxpyMemory<OtherType> &other)
+    {
+        convert_with(other,
+                     [](OtherType val) { return static_cast<ValueType>(val); });
+    }
+
+    template <typename OtherType, typename Callable>
+    void convert_with(const AxpyMemory<OtherType> &other,
+                      Callable &&convert_function)
+    {
+        convert_mtx(x_info_, other.cpu_x(), cpu_x(), convert_function);
+        convert_mtx(res_info_, other.cpu_res(), cpu_res(), convert_function);
+    }
+
+public:
+    ValueType *cpu_x() { return cpu_x_.data(); }
+    ValueType *cpu_res() { return cpu_res_.data(); }
+    const ValueType *cpu_x() const { return cpu_x_.const_data(); }
+    const ValueType *cpu_res() const { return cpu_res_.const_data(); }
+
+    ValueType *gpu_res() { return gpu_res_.data(); }
+    const ValueType *gpu_x() const { return gpu_x_.const_data(); }
+    const ValueType *gpu_res() const { return gpu_res_.const_data(); }
+
+    // Needed to snapshot/restore res between error measurements
+    Memory<ValueType> &cpu_res_memory() { return cpu_res_; }
+    const Memory<ValueType> &cpu_res_memory() const { return cpu_res_; }
+    Memory<ValueType> &gpu_res_memory() { return gpu_res_; }
+    const Memory<ValueType> &gpu_res_memory() const { return gpu_res_; }
+
+    // Informations about the x and res vectors
+    const matrix_info x_info_;
+    const matrix_info res_info_;
+
+private:
+    Memory<ValueType> cpu_x_;
+    Memory<ValueType> cpu_res_;
+
+    Memory<ValueType> gpu_x_;
+    Memory<ValueType> gpu_res_;
+};

--- a/cuda/dot_kernels.cuh
+++ b/cuda/dot_kernels.cuh
@@ -17,52 +17,8 @@
 #include "utils.cuh"
 
 
-constexpr int grids_per_sm{32};
+constexpr int dot_blocks_per_sm{32};
 constexpr int dot_block_size{1024};
-
-
-/**
- * This class acts as an RAII wrapper for information needed for all BLAS
- * kernels in this file. It stores the CUDA device property and manages a small
- * CUDA device memory buffer, which is used for some global reduction kernel.
- **/
-class myBlasHandle {
-public:
-    myBlasHandle()
-    {
-        CUDA_CALL(cudaGetDeviceProperties(&device_prop_, 0));
-        CUDA_CALL(cudaMalloc(&device_storage_, device_storage_size_bytes_));
-    }
-
-    /**
-     * Returns the CUDA device property for the GPU with the ID 0.
-     *
-     * @returns the CUDA device property for the GPU with the ID 0.
-     */
-    const cudaDeviceProp &get_device_property() const { return device_prop_; }
-
-    /**
-     * Returns a device pointer to a single value of type T.
-     *
-     * @tparam T  Type of the value you want a pointer to.
-     *
-     * @returns a device pointer to a single value of type T.
-     */
-    template <typename T>
-    T *get_device_value_ptr()
-    {
-        static_assert(sizeof(T) < device_storage_size_bytes_,
-                      "The expected type is too large for the device storage!");
-        return reinterpret_cast<T *>(device_storage_);
-    }
-
-    ~myBlasHandle() { cudaFree(&device_storage_); }
-
-private:
-    static constexpr std::size_t device_storage_size_bytes_{16};
-    cudaDeviceProp device_prop_;
-    void *device_storage_;
-};
 
 
 namespace kernel {
@@ -196,7 +152,8 @@ void dot(myBlasHandle *handle, const matrix_info x_info, const ValueType *x,
     constexpr std::int32_t block_size{dot_block_size};
     const dim3 block(block_size, 1, 1);
     const dim3 grid(
-        handle->get_device_property().multiProcessorCount * grids_per_sm, 1, 1);
+        handle->get_device_property().multiProcessorCount * dot_blocks_per_sm,
+        1, 1);
 
     kernel::init_res<<<1, 1>>>(res);
     kernel::dot<block_size, ValueType>
@@ -228,7 +185,8 @@ void acc_dot(myBlasHandle *handle, const matrix_info x_info, const StType *x,
     constexpr std::int32_t block_size{dot_block_size};
     const dim3 block(block_size, 1, 1);
     const dim3 grid(
-        handle->get_device_property().multiProcessorCount * grids_per_sm, 1, 1);
+        handle->get_device_property().multiProcessorCount * dot_blocks_per_sm,
+        1, 1);
 
     // Accessor Setup
     constexpr std::size_t dimensionality{2};

--- a/cuda/gemv_kernels.cuh
+++ b/cuda/gemv_kernels.cuh
@@ -29,9 +29,10 @@ namespace cg = cooperative_groups;
  */
 template <std::int64_t block_size, typename ValueType>
 __global__ __launch_bounds__(block_size) void gemv(
-    const matrix_info m_info, ValueType alpha, const ValueType *__restrict__ mtx,
-    const matrix_info x_info, const ValueType *__restrict__ x,
-    const matrix_info res_info, ValueType beta, ValueType *__restrict__ res)
+    const matrix_info m_info, ValueType alpha,
+    const ValueType *__restrict__ mtx, const matrix_info x_info,
+    const ValueType *__restrict__ x, const matrix_info res_info, ValueType beta,
+    ValueType *__restrict__ res)
 {
     // expect x_info.size[1] == 1
     const std::int64_t row_idx{blockIdx.x};
@@ -178,7 +179,8 @@ void acc_gemv(const matrix_info m_info, ArType alpha, const StType *mtx,
     constexpr std::size_t dimensionality{2};
     std::array<gko::acc::size_type, dimensionality - 1> m_stride{m_info.stride};
     std::array<gko::acc::size_type, dimensionality - 1> x_stride{x_info.stride};
-    std::array<gko::acc::size_type, dimensionality - 1> res_stride{res_info.stride};
+    std::array<gko::acc::size_type, dimensionality - 1> res_stride{
+        res_info.stride};
 
     using accessor =
         gko::acc::reduced_row_major<dimensionality, ArType, StType>;

--- a/cuda/utils.cuh
+++ b/cuda/utils.cuh
@@ -106,6 +106,49 @@ constexpr ValueType ceildiv(ValueType a, ValueType b)
  */
 void synchronize() { CUDA_CALL(cudaDeviceSynchronize()); }
 
+/**
+ * This class acts as an RAII wrapper for information needed for all BLAS
+ * kernels in this file. It stores the CUDA device property and manages a small
+ * CUDA device memory buffer, which is used for some global reduction kernel.
+ **/
+class myBlasHandle {
+public:
+    myBlasHandle()
+    {
+        CUDA_CALL(cudaGetDeviceProperties(&device_prop_, 0));
+        CUDA_CALL(cudaMalloc(&device_storage_, device_storage_size_bytes_));
+    }
+
+    /**
+     * Returns the CUDA device property for the GPU with the ID 0.
+     *
+     * @returns the CUDA device property for the GPU with the ID 0.
+     */
+    const cudaDeviceProp &get_device_property() const { return device_prop_; }
+
+    /**
+     * Returns a device pointer to a single value of type T.
+     *
+     * @tparam T  Type of the value you want a pointer to.
+     *
+     * @returns a device pointer to a single value of type T.
+     */
+    template <typename T>
+    T *get_device_value_ptr()
+    {
+        static_assert(sizeof(T) < device_storage_size_bytes_,
+                      "The expected type is too large for the device storage!");
+        return reinterpret_cast<T *>(device_storage_);
+    }
+
+    ~myBlasHandle() { cudaFree(device_storage_); }
+
+private:
+    static constexpr std::size_t device_storage_size_bytes_{16};
+    cudaDeviceProp device_prop_;
+    void *device_storage_;
+};
+
 
 /**
  * RAII wrapper for a CUDA event


### PR DESCRIPTION
## Description
I've been using this repo for some personal research into ginkgo's reduced memory accessors, and I ended up implementing AXPY support following the same structure as the existing benchmarks. Figured it might be useful to others, so Im sharing it here in case it's of interest. *(Totally understand if this isn't the kind of repo that's looking for contributions)*

## What's new
- `axpy_memory.cuh`: `AxpyMemory` class managing host/device memory for the AXPY benchmarks.
- `axpy_kernels.cuh`: 3 AXPY implementations:
    - a plain custom CUDA kernel
    - an accessor-based kernel using `gko::acc::reduced_row_major`
    - a thin wrapper around the cuBLAS AXPY calls
- `axpy_benchmark.cu`: the benchmark driver, following the same CLI structure (`--size`, `--error`) as the other benchmarks.

## Refactor
- The `myBlasHandle` class was originally defined in `dot_kernels.cuh`, but `axpy_kernels.cuh` needs it too, so I moved it onto `utils.cuh`.

## Bug fixes / naming cleanup
- Destructor bug in `myBlasHandle`:
    ```cpp
    // device_storage_ is already a void* device pointer

    // before
    ~myBlasHandle() { cudaFree(&device_storage_); }

    // after
    ~myBlasHandle() { cudaFree(device_storage_); }
    ```

- Fixed misleading name: `grid_per_sm` was actually describing the number of *blocks* launched per SM (its used as `multiProcessorCount * grid_per_sm` to size the grid). I renamed it to blocks_per_sm

- Renamed generic constants to avoid name clashes/ambiguity:
    ```cpp
    // before
    constexpr int blocks_size{1024};
    constexpr int grid_per_sm{32};

    // after
    constexpr int dot_blocks_size{1024};
    constexpr int dot_blocks_per_sm{32};
    ```
    I used the same `<kernel>_block_size`/`<kernel>_blocks_per_sm` naming for the new AXPY constants.

## Misc
- Added a `.gitignore` for CMake build artifacts.

## Testing
- Successfully ran the AXPY benchmarks locally
- Checked for leaks with `compute-sanitizer` (clean after the destructor fix).
- Profiled with Nsight Compute and reproduced the expected roofline behavior across the custom/accessor/cuBLAS variants.